### PR TITLE
Add overrides (GH #8)

### DIFF
--- a/lib/Perl/Critic/Policy/Perlsecret.pm
+++ b/lib/Perl/Critic/Policy/Perlsecret.pm
@@ -48,7 +48,7 @@ sub violates {
         'Baby Cart'                   => \&_baby_cart,
         'Bang Bang'                   => \&_bang_bang,
         'Inchworm'                    => \&_inchworm,
-        'Inchworm on a stick'         => \&_inchworm_on_a_stick,
+        'Inchworm on a Stick'         => \&_inchworm_on_a_stick,
         'Space Station'               => \&_space_station,
         'Goatse'                      => \&_goatse,
         'Flaming X-Wing'              => \&_flaming_x_wing,
@@ -58,9 +58,9 @@ sub violates {
         'Phillips'                    => \&_phillips,
         'Torx'                        => \&_torx,
         'Pozidriv'                    => \&_pozidriv,
-        'Winking fat comma'           => \&_winking_fat_comma,
+        'Winking Fat Comma'           => \&_winking_fat_comma,
         'Enterprise'                  => \&_enterprise,
-        'Key of truth'                => \&_key_of_truth,
+        'Key of Truth'                => \&_key_of_truth,
         'Abbott and Costello'         => \&_abbott_and_costello,
     );
 

--- a/lib/Perl/Critic/Policy/Perlsecret.pm
+++ b/lib/Perl/Critic/Policy/Perlsecret.pm
@@ -44,10 +44,10 @@ sub violates {
 
     # Eskimo Greeting skipped as only used in one liners
     my %violations = (
-        'Venus'     => \&_venus,
-        'Baby Cart' => \&_baby_cart,
-        'Bang Bang' => \&_bang_bang,
-        'Inchworm'  => \&_inchworm,
+        'Venus'                       => \&_venus,
+        'Baby Cart'                   => \&_baby_cart,
+        'Bang Bang'                   => \&_bang_bang,
+        'Inchworm'                    => \&_inchworm,
         'Inchworm on a stick'         => \&_inchworm_on_a_stick,
         'Space Station'               => \&_space_station,
         'Goatse'                      => \&_goatse,

--- a/lib/Perl/Critic/Policy/Perlsecret.pm
+++ b/lib/Perl/Critic/Policy/Perlsecret.pm
@@ -25,6 +25,28 @@ our $VERSION = '0.0.5';
 Readonly::Scalar my $DESCRIPTION => 'Perlsecret risk.';
 Readonly::Scalar my $EXPLANATION => 'Perlsecret detected: %s';
 
+# Eskimo Greeting skipped as only used in one liners
+Readonly::Hash my %default_violations => (
+    'Venus'                       => \&_venus,
+    'Baby Cart'                   => \&_baby_cart,
+    'Bang Bang'                   => \&_bang_bang,
+    'Inchworm'                    => \&_inchworm,
+    'Inchworm on a Stick'         => \&_inchworm_on_a_stick,
+    'Space Station'               => \&_space_station,
+    'Goatse'                      => \&_goatse,
+    'Flaming X-Wing'              => \&_flaming_x_wing,
+    'Kite'                        => \&_kite,
+    'Ornate Double Edged Sword'   => \&_ornate_double_edged_sword,
+    'Flathead'                    => \&_flathead,
+    'Phillips'                    => \&_phillips,
+    'Torx'                        => \&_torx,
+    'Pozidriv'                    => \&_pozidriv,
+    'Winking Fat Comma'           => \&_winking_fat_comma,
+    'Enterprise'                  => \&_enterprise,
+    'Key of Truth'                => \&_key_of_truth,
+    'Abbott and Costello'         => \&_abbott_and_costello,
+);
+
 sub default_severity {
     return $Perl::Critic::Utils::SEVERITY_HIGHEST;
 }
@@ -42,28 +64,9 @@ sub applies_to {
 sub violates {
     my ( $self, $element, $doc ) = @_;
 
-    # Eskimo Greeting skipped as only used in one liners
-    my %violations = (
-        'Venus'                       => \&_venus,
-        'Baby Cart'                   => \&_baby_cart,
-        'Bang Bang'                   => \&_bang_bang,
-        'Inchworm'                    => \&_inchworm,
-        'Inchworm on a Stick'         => \&_inchworm_on_a_stick,
-        'Space Station'               => \&_space_station,
-        'Goatse'                      => \&_goatse,
-        'Flaming X-Wing'              => \&_flaming_x_wing,
-        'Kite'                        => \&_kite,
-        'Ornate Double Edged Sword'   => \&_ornate_double_edged_sword,
-        'Flathead'                    => \&_flathead,
-        'Phillips'                    => \&_phillips,
-        'Torx'                        => \&_torx,
-        'Pozidriv'                    => \&_pozidriv,
-        'Winking Fat Comma'           => \&_winking_fat_comma,
-        'Enterprise'                  => \&_enterprise,
-        'Key of Truth'                => \&_key_of_truth,
-        'Abbott and Costello'         => \&_abbott_and_costello,
     );
 
+    my %violations = %default_violations;
     for my $policy ( keys %violations ) {
         if ( $violations{$policy}->($element) ) {
             return $self->violation( $DESCRIPTION . " $policy ",


### PR DESCRIPTION
Two additional options introduced:

* `allow_secrets`
* `disallow_secrets`

`disallow_secrets` can be set as the policies we should enforce. If none are provided by config, we take the defaults we know about, which are all of them.

Then `allow_secrets` allows to set secrets which are allowed and will not trigger a violation.

I tried testing this in the test script but I couldn't set the configuration option. :/

Otherwise, it works. :P
