### PR TITLE
Fix disallow code:

### DIFF
--- a/lib/Perl/Critic/Policy/Perlsecret.pm
+++ b/lib/Perl/Critic/Policy/Perlsecret.pm
@@ -102,18 +102,23 @@ sub violates {
         $self->{'_disallow_secrets'}
     );
 
+    @disallowed
+        or @disallowed = keys %default_violations;
+
     my @allowed = $self->read_config_list(
         $self->{'_allow_secrets'}
     );
 
-    my %violations = %default_violations;
+    my %violations;
     foreach my $secret (@disallowed) {
         if ( ! exists $default_violations{$secret} ) {
             croak("$secret is not a known secret");
         }
 
         first { $secret eq $_ } @allowed
-            and delete $violations{$secret};
+            and next;
+
+        $violations{$secret} = $default_violations{$secret};
     }
 
     for my $policy ( keys %violations ) {

--- a/t/40-overrides.t
+++ b/t/40-overrides.t
@@ -4,14 +4,14 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::More tests               => 3;
 use Test::Fatal 'dies_ok';
+use Test::More tests               => 6;
 use Perl::Critic::Policy::Perlsecret;
 use Perl::Critic::TestUtils qw( pcritique );
 
 my $policy = Perl::Critic::Policy::Perlsecret->new(
     allow_secrets    => 'Venus',
-    disallow_secrets => 'Baby Cart',
+    disallow_secrets => 'Baby Cart, Venus',
 );
 
 my @parameters = $policy->supported_parameters();
@@ -28,17 +28,42 @@ is_deeply \@parameters,
         'default_string' =>
             'Venus, Baby Cart, Bang Bang, Inchworm, Inchworm on a Stick, Space Station, Goatse, Flaming X-Wing, Kite, Ornate Double Edged Sword, Flathead, Phillips, Torx, Pozidriv, Winking Fat Comma, Enterprise, Key of Truth, Abbott and Costello'
     }
-    ];
+    ],
+    'Correct parameters';
 
 # Venus
 my $code = <<'__CODE__';
 	    print 0+ '23a';
 	    #print +0 '23a'; should not be detected as is a comment
 	    print +0 '23a';
+        ( 'foo' => 'bar' )!!x$baz;
 	}
 __CODE__
-is pcritique( 'Perlsecret', \$code, { allow_secrets => 'Venus' } ), 0,
+
+my $config
+    = { allow_secrets => 'Venus', disallow_secrets => 'Baby Cart, Venus' };
+
+is pcritique( 'Perlsecret', \$code, $config ), 0,
     '0 x Venus expected, as Venus allowed';
 
 dies_ok { pcritique( 'Perlsecret', \$code, { disallow_secrets => 'no_chance' } ) }
     'Croaks if invalid disallow_secrets set';
+
+# Baby cart
+$code = <<'__CODE__';
+    print "@{[function_call()]}";
+__CODE__
+
+is pcritique( 'Perlsecret', \$code, $config ), 1,
+    '1 x Baby Cart expected';
+
+# Bang Bang
+$code = <<'__CODE__';
+    !!$var;
+__CODE__
+
+is pcritique( 'Perlsecret', \$code, $config ), 0,
+    'No violations found because Bang Bang not disallowed';
+
+is pcritique( 'Perlsecret', \$code, {} ), 1,
+    'Bang Bang is in the default disallow';


### PR DESCRIPTION
There was a major bug in the code I didn't spot.

Instead of creating a list from the default _OR_ the disallow,
we create from the default and then check against the disallow,
and then use the ones we got from the default. In short, buggy.

This is now cleaner:
- Create a list from the disallow or - if that doesn't exist - from
  the default.
- Check that against the allow list on whether to check it or not.

I've also added more tests to verify this.
